### PR TITLE
Fix identifiers cache invalidation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -517,7 +517,7 @@ To manually trigger validation on a suite:
 
 [source,ruby]
 ----
-errors = suite.validate
+errors = suite.validate_all
 if errors.any?
   puts "Validation errors:"
   errors.each { |error| puts "- #{error}" }

--- a/lib/modspec/conformance_class.rb
+++ b/lib/modspec/conformance_class.rb
@@ -31,11 +31,11 @@ module Modspec
       map_element "reference", to: :reference
     end
 
-    def validate
+    def validate_all
       errors = []
       errors.concat(validate_identifier_prefix)
       errors.concat(validate_class_children_mapping)
-      errors.concat(tests.flat_map(&:validate))
+      errors.concat(tests.flat_map(&:validate_all))
       errors
     end
 

--- a/lib/modspec/conformance_test.rb
+++ b/lib/modspec/conformance_test.rb
@@ -36,7 +36,7 @@ module Modspec
 
     attr_accessor :corresponding_requirements, :parent_class
 
-    def validate
+    def validate_all
       errors = []
       errors.concat(validate_requirement_mapping)
       errors.concat(validate_class_mapping)

--- a/lib/modspec/normative_statement.rb
+++ b/lib/modspec/normative_statement.rb
@@ -46,7 +46,7 @@ module Modspec
       map_element "parts", to: :parts
     end
 
-    def validate
+    def validate_all
       errors = []
       errors.concat(validate_dependencies)
       errors.concat(validate_nested_requirement)

--- a/lib/modspec/normative_statement.rb
+++ b/lib/modspec/normative_statement.rb
@@ -46,19 +46,19 @@ module Modspec
       map_element "parts", to: :parts
     end
 
-    def validate_all
+    def validate_all(suite)
       errors = []
-      errors.concat(validate_dependencies)
+      errors.concat(validate_dependencies(suite))
       errors.concat(validate_nested_requirement)
       errors
     end
 
     private
 
-    def validate_dependencies
+    def validate_dependencies(suite)
       errors = []
       all_dependencies = (dependencies + indirect_dependency + implements).flatten.compact.map(&:to_s)
-      all_identifiers = Suite.instance.all_identifiers.map(&:to_s)
+      all_identifiers = suite.all_identifiers.map(&:to_s)
       all_dependencies.each do |dep|
         errors << "Requirement #{identifier} has an invalid dependency: #{dep}" unless all_identifiers.include?(dep)
       end

--- a/lib/modspec/normative_statements_class.rb
+++ b/lib/modspec/normative_statements_class.rb
@@ -31,11 +31,11 @@ module Modspec
       map_element "source", to: :source
     end
 
-    def validate
+    def validate_all
       errors = []
       errors.concat(validate_identifier_prefix)
       errors.concat(validate_class_children_mapping)
-      errors.concat(normative_statements.flat_map(&:validate))
+      errors.concat(normative_statements.flat_map(&:validate_all))
       errors
     end
 

--- a/lib/modspec/normative_statements_class.rb
+++ b/lib/modspec/normative_statements_class.rb
@@ -31,11 +31,11 @@ module Modspec
       map_element "source", to: :source
     end
 
-    def validate_all
+    def validate_all(suite)
       errors = []
       errors.concat(validate_identifier_prefix)
       errors.concat(validate_class_children_mapping)
-      errors.concat(normative_statements.flat_map(&:validate_all))
+      errors.concat(normative_statements.flat_map { |n| n.validate_all(suite) })
       errors
     end
 

--- a/lib/modspec/suite.rb
+++ b/lib/modspec/suite.rb
@@ -17,14 +17,14 @@ module Modspec
       map_element "conformance-classes", to: :conformance_classes
     end
 
-    def validate
+    def validate_all
       setup_relationships
       errors = []
       errors.concat(validate_cycles)
       errors.concat(validate_label_uniqueness)
       errors.concat(validate_dependencies)
-      errors.concat(normative_statements_classes.flat_map(&:validate))
-      errors.concat(conformance_classes.flat_map(&:validate))
+      errors.concat(normative_statements_classes.flat_map(&:validate_all))
+      errors.concat(conformance_classes.flat_map(&:validate_all))
       errors
     end
 
@@ -41,7 +41,7 @@ module Modspec
 
       combined_suite.name = "#{name} + #{other_suite.name}"
 
-      errors = combined_suite.validate
+      errors = combined_suite.validate_all
       if errors.any?
         puts "Warning: The combined suite has validation errors:"
         errors.each { |error| puts "  #{error}" }

--- a/lib/modspec/suite.rb
+++ b/lib/modspec/suite.rb
@@ -19,11 +19,12 @@ module Modspec
 
     def validate_all
       setup_relationships
+      self.all_identifiers = nil
       errors = []
       errors.concat(validate_cycles)
       errors.concat(validate_label_uniqueness)
       errors.concat(validate_dependencies)
-      errors.concat(normative_statements_classes.flat_map(&:validate_all))
+      errors.concat(normative_statements_classes.flat_map { |n| n.validate_all(self) })
       errors.concat(conformance_classes.flat_map(&:validate_all))
       errors
     end
@@ -32,6 +33,7 @@ module Modspec
       raise ArgumentError, "Argument must be a Modspec::Suite" unless other_suite.is_a?(Modspec::Suite)
 
       combined_suite = dup
+      combined_suite.all_identifiers = nil
       combined_suite.normative_statements_classes += other_suite.normative_statements_classes
       combined_suite.conformance_classes += other_suite.conformance_classes
 
@@ -50,16 +52,14 @@ module Modspec
       combined_suite
     end
 
-    def self.instance
-      @instance ||= new
-    end
-
     def all_identifiers
       @all_identifiers ||= (normative_statements_classes.flat_map(&:normative_statements) +
                             conformance_classes.flat_map(&:tests) +
                             normative_statements_classes +
                             conformance_classes).map(&:identifier)
     end
+
+    attr_writer :all_identifiers
 
     def resolve_conflicts(other_suite)
       resolve_conflicts_for(normative_statements_classes, other_suite.normative_statements_classes)

--- a/spec/modspec/conformance_class_spec.rb
+++ b/spec/modspec/conformance_class_spec.rb
@@ -135,9 +135,9 @@ RSpec.describe Modspec::ConformanceClass do
     expect(conformance_class.tests.length).to eq(2)
   end
 
-  describe "#validate" do
+  describe "#validate_all" do
     it "returns no errors for a valid conformance class" do
-      errors = suite.validate
+      errors = suite.validate_all
       if errors.any?
         puts "Validation errors:"
         errors.each { |error| puts "  #{error}" }
@@ -147,7 +147,7 @@ RSpec.describe Modspec::ConformanceClass do
 
     it "returns errors if there are no conformance tests" do
       conformance_class.tests = []
-      errors = conformance_class.validate
+      errors = conformance_class.validate_all
       expect(errors).not_to be_empty
     end
   end

--- a/spec/modspec/conformance_test_spec.rb
+++ b/spec/modspec/conformance_test_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe Modspec::ConformanceTest do
     expect(conformance_test.targets).to eq(["/req/basic-ypr/position"])
   end
 
-  describe "#validate" do
+  describe "#validate_all" do
     it "returns no errors for a valid conformance test" do
-      errors = conformance_test.validate
+      errors = conformance_test.validate_all
       expect(errors).to be_empty
     end
   end

--- a/spec/modspec/normative_statement_spec.rb
+++ b/spec/modspec/normative_statement_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe Modspec::NormativeStatement do
     expect(%w[requirement recommendation permission]).to include(normative_statement.obligation)
   end
 
-  describe "#validate" do
+  describe "#validate_all" do
     it "returns no errors for a valid normative statement" do
-      errors = normative_statement.validate
+      errors = normative_statement.validate_all
       expect(errors).to be_empty
     end
 

--- a/spec/modspec/normative_statement_spec.rb
+++ b/spec/modspec/normative_statement_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Modspec::NormativeStatement do
       subject: "Basic_YPR.position",
       inherit: ["/req/global/sdu"],
       dependencies: ["/req/tangent-point"],
-      guidance: "Ensure the coordinate system is correctly specified."
+      guidance: ["Ensure the coordinate system is correctly specified."]
     )
   end
 

--- a/spec/modspec/normative_statement_spec.rb
+++ b/spec/modspec/normative_statement_spec.rb
@@ -48,10 +48,6 @@ RSpec.describe Modspec::NormativeStatement do
     suite
   end
 
-  before do
-    allow(Modspec::Suite).to receive(:instance).and_return(suite)
-  end
-
   it "has an identifier" do
     expect(normative_statement.identifier).to eq("/req/basic-ypr/position")
   end
@@ -70,7 +66,7 @@ RSpec.describe Modspec::NormativeStatement do
 
   describe "#validate_all" do
     it "returns no errors for a valid normative statement" do
-      errors = normative_statement.validate_all
+      errors = normative_statement.validate_all(suite)
       expect(errors).to be_empty
     end
 

--- a/spec/modspec/normative_statements_class_spec.rb
+++ b/spec/modspec/normative_statements_class_spec.rb
@@ -40,15 +40,15 @@ RSpec.describe Modspec::NormativeStatementsClass do
     expect(normative_statements_class.normative_statements.length).to eq(2)
   end
 
-  describe "#validate" do
+  describe "#validate_all" do
     it "returns no errors for a valid normative statements class" do
-      errors = normative_statements_class.validate
+      errors = normative_statements_class.validate_all
       expect(errors).to be_empty
     end
 
     it "returns errors if there are no normative statements" do
       normative_statements_class.normative_statements = []
-      errors = normative_statements_class.validate
+      errors = normative_statements_class.validate_all
       expect(errors).not_to be_empty
     end
   end

--- a/spec/modspec/normative_statements_class_spec.rb
+++ b/spec/modspec/normative_statements_class_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Modspec::NormativeStatementsClass do
     )
   end
 
+  let(:suite) do
+    suite = Modspec::Suite.new
+    suite.normative_statements_classes = [normative_statements_class]
+    suite
+  end
+
   it "has an identifier" do
     expect(normative_statements_class.identifier).to eq("/req/basic-ypr")
   end
@@ -42,13 +48,13 @@ RSpec.describe Modspec::NormativeStatementsClass do
 
   describe "#validate_all" do
     it "returns no errors for a valid normative statements class" do
-      errors = normative_statements_class.validate_all
+      errors = normative_statements_class.validate_all(suite)
       expect(errors).to be_empty
     end
 
     it "returns errors if there are no normative statements" do
       normative_statements_class.normative_statements = []
-      errors = normative_statements_class.validate_all
+      errors = normative_statements_class.validate_all(suite)
       expect(errors).not_to be_empty
     end
   end

--- a/spec/modspec/suite_spec.rb
+++ b/spec/modspec/suite_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Modspec::Suite do
     end
   end
 
-  describe "#validate" do
+  describe "#validate_all" do
     it "returns no errors for a valid combined suite" do
       base_suite = described_class.from_yaml(rc_yaml)
       combined_suite = base_suite
@@ -37,7 +37,7 @@ RSpec.describe Modspec::Suite do
                        .combine(time_suite)
                        .combine(frame_spec_suite)
 
-      errors = combined_suite.validate
+      errors = combined_suite.validate_all
       if errors.any?
         puts "Validation errors:"
         errors.each { |error| puts "  #{error}" }
@@ -67,7 +67,7 @@ RSpec.describe Modspec::Suite do
                        .combine(time_suite)
                        .combine(frame_spec_suite)
 
-      errors = combined_suite.validate
+      errors = combined_suite.validate_all
       if errors.any?
         puts "Validation errors:"
         errors.each { |error| puts "  #{error}" }
@@ -90,7 +90,7 @@ RSpec.describe Modspec::Suite do
       expect(combined_suite.conformance_classes).not_to be_empty
 
       # Validate the combined suite
-      errors = combined_suite.validate
+      errors = combined_suite.validate_all
 
       if errors.any?
         puts "Validation errors:"


### PR DESCRIPTION
This PR fixes issues in #7:
- `#validate` from lutaml-model's got overriden. Fixed by choosing different name instead (`#validate_all`).
- Normative statement guidance in a spec was set to a string while it expects a collection of string. Fixed by simply wrapping the string in an array.
- Combined suite get invalid cached identifiers which cause validation to fail. Fixed by resetting it when combining/validating suite and pass the suite explicitly to validate normative statements.