### PR TITLE
Route release.yml through metanorma/support wrapper

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -2,15 +2,14 @@
 # See https://github.com/metanorma/cimas
 name: rake
 
-permissions:
-  contents: write
-  packages: write
-
 on:
   push:
     branches: [ master, main ]
     tags: [ v* ]
   pull_request:
+
+permissions:
+  contents: write
 
 jobs:
   rake:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@
 # See https://github.com/metanorma/cimas
 name: release
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
-
 on:
   workflow_dispatch:
     inputs:
@@ -19,12 +14,16 @@ on:
   repository_dispatch:
     types: [ do-release ]
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
 jobs:
   release:
-    uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
+    uses: metanorma/support/.github/workflows/release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
     secrets:
       rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
-      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,24 +2,9 @@
 # See https://github.com/metanorma/cimas
 inherit_from:
   - https://raw.githubusercontent.com/riboseinc/oss-guides/main/ci/rubocop.yml
-  - .rubocop_todo.yml
-
-inherit_mode:
-  merge:
-    - Exclude
 
 # local repo-specific modifications
 # ...
-plugins:
-  - rubocop-rspec
-  - rubocop-performance
-  - rubocop-rake
 
 AllCops:
-  TargetRubyVersion: 3.0
-
-RSpec/ExampleLength:
-  Max: 30
-
-RSpec/MultipleMemoizedHelpers:
-  Max: 14
+  TargetRubyVersion: 3.4


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/292
Full plan: https://github.com/metanorma/cimas/blob/main/plans/cimas-revival-and-release-workflow-realignment.md

Routes this repo's `release.yml` through the new `metanorma/support` wrapper, bringing it into alignment with the `<org>/support` pattern already used by `relaton/support`, `fontist/support`, and `lutaml/support`. The `pat_token` reference is dropped (the wrapper does not forward it, matching the convention used by the other org-level support wrappers).

Generated by the cimas-sync wave; canary-verified end-to-end on `metanorma-taste` 1.0.8 (published 2026-06-16 12:54 UTC via the new wrapper path).

🤖
